### PR TITLE
Unwrap whole-document ```markdown fences from specs

### DIFF
--- a/src/db/migrate.js
+++ b/src/db/migrate.js
@@ -22,8 +22,70 @@ async function migrate(config) {
   await seedSelfApp(pool, config);
   await backfillEvents(pool);
   await backfillVotesRequired(pool);
+  // Must run BEFORE backfillOrphanedSpecDrafts: unwrapping spec_md after that
+  // freezes a wrapped version would leave the frozen copy wrapped while the
+  // live buffer is clean, churning a new version on every boot.
+  await backfillFenceWrappedSpecs(pool);
   await backfillOrphanedSpecDrafts(pool);
   await migrateAppDbsToPerRole(pool, config);
+}
+
+// One-shot, idempotent backfill that unwraps specs a scout/spec-author LLM
+// stored fully enclosed in a single ```markdown … ``` fence — which made the
+// whole spec render as one big code block instead of formatted markdown
+// (session 153; 11 sessions at time of writing). The conservative unwrap can't
+// be expressed in pure SQL, so we read the spec rows, run each through
+// stripSpecWrapperFence(), and write back only the ones that actually change.
+// Covers BOTH the live buffer (chat_sessions.spec_md — what the viewer shows
+// as "latest") and the frozen history (chat_session_specs.content — what older
+// version cards open). Row counts here are tiny (≈ one per session), so a full
+// scan is cheaper than escaping a backtick LIKE prefilter and is robust to
+// leading whitespace.
+//
+// Idempotent by construction: once unwrapped, a value no longer opens with a
+// strippable wrapper, so stripSpecWrapperFence() returns it unchanged and no
+// UPDATE fires on subsequent boots.
+async function backfillFenceWrappedSpecs(pool) {
+  const { stripSpecWrapperFence } = require('../services/spec-format');
+  let liveFixed = 0;
+  let versionFixed = 0;
+  try {
+    const { rows: live } = await pool.query(
+      `SELECT id, spec_md FROM chat_sessions
+        WHERE spec_md IS NOT NULL AND length(btrim(spec_md)) > 0`
+    );
+    for (const row of live) {
+      const unwrapped = stripSpecWrapperFence(row.spec_md);
+      if (unwrapped !== row.spec_md) {
+        await pool.query('UPDATE chat_sessions SET spec_md = $1 WHERE id = $2', [unwrapped, row.id]);
+        liveFixed++;
+      }
+    }
+
+    const { rows: versions } = await pool.query(
+      `SELECT session_id, version, content FROM chat_session_specs
+        WHERE content IS NOT NULL AND length(btrim(content)) > 0`
+    );
+    for (const row of versions) {
+      const unwrapped = stripSpecWrapperFence(row.content);
+      if (unwrapped !== row.content) {
+        await pool.query(
+          'UPDATE chat_session_specs SET content = $1 WHERE session_id = $2 AND version = $3',
+          [unwrapped, row.session_id, row.version]
+        );
+        versionFixed++;
+      }
+    }
+  } catch (err) {
+    log.warn('db', 'fence-wrapped spec backfill skipped (query failed)', { err: err.message });
+    return;
+  }
+
+  if (liveFixed || versionFixed) {
+    log.info('db', 'Unwrapped fence-wrapped specs', { liveFixed, versionFixed });
+  } else {
+    log.debug('db', 'No fence-wrapped specs to backfill');
+  }
 }
 
 // #69: one-shot, idempotent backfill that freezes any orphaned live spec

--- a/src/routes/sessions.js
+++ b/src/routes/sessions.js
@@ -109,6 +109,12 @@ function buildSpecPreview(content, max = 400) {
   return `${cut}…`;
 }
 
+// Unwrap a whole-document ```markdown fence a scout/spec-author LLM sometimes
+// emits around the entire spec (see src/services/spec-format.js for the why
+// and the conservative rules). Re-exported below so existing importers and
+// tests can keep requiring it from this module.
+const { stripSpecWrapperFence } = require('../services/spec-format');
+
 // #27: freeze the current spec content as a new immutable version in
 // chat_session_specs and return its version number. Every spec mutation
 // (write_spec / edit_spec / scout) calls this and tags its inline spec
@@ -1856,6 +1862,8 @@ const WRITE_SPEC_TOOL = {
           + '(Goal, Screens, Data Model, Edge Cases, etc.). Prefer decisions over questions: only add a '
           + '"Questions" section for items that genuinely block implementation; put non-blocking notes '
           + 'under "Considerations" or "Deferred work" instead. '
+          + 'Pass RAW markdown — do NOT wrap the whole spec in a code fence (no leading ```markdown / trailing ```), '
+          + 'or it renders as one big code block. '
           + 'The spec renders as standard CommonMark: if a fenced code block must itself contain a '
           + 'triple-backtick fence, wrap the outer block in a four-backtick fence so the inner fence does '
           + 'not close it early and break the rest of the doc.',
@@ -1993,7 +2001,7 @@ function buildMayorMessages(history) {
 // open Spec panel re-renders live. Returns a tool_result summary the
 // phase-2 wrap-up will narrate to the user.
 async function runWriteSpecTool({ pool, session, send, sendStatus, toolInput }) {
-  const content = typeof toolInput?.content === 'string' ? toolInput.content : '';
+  const content = stripSpecWrapperFence(typeof toolInput?.content === 'string' ? toolInput.content : '');
   if (!content.trim()) {
     await sendStatus('write_spec was called with empty content; the spec was not updated.');
     return {
@@ -2098,7 +2106,9 @@ async function runEditSpecTool({ pool, session, send, sendStatus, toolInput }) {
   }
 
   const matchIdx = currentSpec.indexOf(oldText);
-  const updated = currentSpec.slice(0, matchIdx) + newText + currentSpec.slice(matchIdx + oldText.length);
+  const updated = stripSpecWrapperFence(
+    currentSpec.slice(0, matchIdx) + newText + currentSpec.slice(matchIdx + oldText.length)
+  );
 
   await pool.query(
     'UPDATE chat_sessions SET spec_md = $1 WHERE id = $2',
@@ -2175,7 +2185,9 @@ The spec is rendered as markdown in a viewer that follows standard CommonMark fe
 
 Do NOT pad the spec with open questions. Only include a "Questions" section for things that genuinely BLOCK implementation — decisions the coding agent cannot reasonably make on its own and that would change what gets built. Make a sensible default choice wherever you can and state it, rather than asking. Non-blocking items — things worth noting but not required to answer before building — belong under "Considerations" (trade-offs, assumptions, things to keep in mind) or "Deferred work" (out-of-scope or follow-up items), NOT as questions.
 
-Your final assistant message must be ONLY the markdown spec — no preamble, no "I'll investigate...", no "Here's the spec:". The host captures that final message verbatim and stores it as the session's spec doc.`;
+Your final assistant message must be ONLY the markdown spec — no preamble, no "I'll investigate...", no "Here's the spec:". The host captures that final message verbatim and stores it as the session's spec doc.
+
+CRITICAL: Output the spec as RAW markdown. Do NOT wrap your whole response in a code fence — no leading \`\`\`markdown line and no trailing \`\`\`. A whole-document fence makes the spec render as one big code block instead of formatted markdown. Fences are only for actual code/quoted snippets INSIDE the spec.`;
 
   // Ensure the long-lived worker is warm before exec'ing run-cc.sh inside
   // it. Cold-start cost (clone + checkout + sleep wrapper) is paid here on
@@ -2277,7 +2289,7 @@ Your final assistant message must be ONLY the markdown spec — no preamble, no 
       return { toolResultText: summaryParts.join('\n\n') || 'Stopped.', isError: true };
     }
 
-    const ccText = (result.lastResultText || '').trim();
+    const ccText = stripSpecWrapperFence((result.lastResultText || '').trim());
 
     if (result.fatalError) {
       isError = true;
@@ -3085,4 +3097,4 @@ CMD ["node", "server.js"]
   return { containerId, stagingUrl, hostname };
 }
 
-module.exports = { sessionRoutes, getActiveWorkerCount, runSyncMain, persistBehindMain, buildSpecPreview };
+module.exports = { sessionRoutes, getActiveWorkerCount, runSyncMain, persistBehindMain, buildSpecPreview, stripSpecWrapperFence };

--- a/src/services/spec-format.js
+++ b/src/services/spec-format.js
@@ -1,0 +1,52 @@
+// Spec-text normalization shared by the spec-capture path (routes/sessions.js)
+// and the one-time backfill (db/migrate.js).
+
+// A scout / spec-author LLM sometimes wraps its ENTIRE markdown spec in a
+// single ```markdown … ``` fence — it reads "produce a markdown document" as
+// "emit one fenced markdown block". Stored verbatim, that makes the whole spec
+// render as one big code block instead of formatted markdown (session 153;
+// ~13% of specs in prod). This unwraps that case so spec_md holds raw markdown.
+//
+// Deliberately conservative — it only strips when the document is EXACTLY one
+// fenced block: the first non-empty line is an opening fence whose info string
+// is empty or markdown-ish (markdown/md/gfm), and the matching closing fence
+// (same marker char, length ≥ opener per CommonMark) is the LAST non-empty
+// line with nothing after it. A spec that merely starts with a code block, has
+// content after the fence, or is fenced as another language (```json, ```js,
+// …) is returned unchanged. When inner triple-backtick fences make the wrapper
+// boundary ambiguous (the F6 case), the closing fence won't be last → we leave
+// it alone rather than guess.
+function stripSpecWrapperFence(content) {
+  if (typeof content !== 'string') return content;
+  const text = content.trim();
+  if (!text) return content;
+
+  const lines = text.split('\n');
+  const open = /^([`~]{3,})(.*)$/.exec(lines[0]);
+  if (!open) return content;
+  const fence = open[1];
+  const marker = fence[0];
+  const info = open[2].trim().toLowerCase();
+  // A valid opener's info string can't contain the fence char, and we only
+  // unwrap markdown-ish (or unlabeled) wrappers.
+  if (info.includes(marker)) return content;
+  if (info !== '' && info !== 'markdown' && info !== 'md' && info !== 'gfm') return content;
+
+  // Closing fence: a line that is only the marker char repeated ≥ opener len.
+  const closeRe = new RegExp(`^\\${marker}{${fence.length},}\\s*$`);
+  let closeIdx = -1;
+  for (let i = 1; i < lines.length; i++) {
+    if (closeRe.test(lines[i])) { closeIdx = i; break; }
+  }
+  if (closeIdx === -1) return content;
+  // Any real content after the (first) closing fence means this isn't a
+  // whole-document wrapper — bail.
+  for (let i = closeIdx + 1; i < lines.length; i++) {
+    if (lines[i].trim()) return content;
+  }
+
+  const inner = lines.slice(1, closeIdx).join('\n').trim();
+  return inner || content;
+}
+
+module.exports = { stripSpecWrapperFence };

--- a/tests/spec-wrapper.test.js
+++ b/tests/spec-wrapper.test.js
@@ -1,0 +1,82 @@
+// Tests for stripSpecWrapperFence (src/routes/sessions.js) — the unwrap that
+// undoes a scout/spec-author LLM wrapping its ENTIRE markdown spec in a single
+// ```markdown … ``` fence (session 153; ~13% of prod specs rendered as one big
+// code block). The helper must be aggressive enough to catch the real failure
+// mode but conservative enough never to mangle a legitimate spec.
+//
+// Run with: node --test tests/spec-wrapper.test.js
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { stripSpecWrapperFence } = require('../src/routes/sessions.js');
+
+const SPEC = '# Spec: Thing\n\n## Goal\n\nDo the thing.\n\n- a\n- b';
+
+test('unwraps a whole-document ```markdown fence (the session 153 case)', () => {
+  const wrapped = '```markdown\n' + SPEC + '\n```';
+  assert.equal(stripSpecWrapperFence(wrapped), SPEC);
+});
+
+test('unwraps an unlabeled ``` fence', () => {
+  assert.equal(stripSpecWrapperFence('```\n' + SPEC + '\n```'), SPEC);
+});
+
+test('unwraps ```md and ```gfm (and is case-insensitive)', () => {
+  assert.equal(stripSpecWrapperFence('```md\n' + SPEC + '\n```'), SPEC);
+  assert.equal(stripSpecWrapperFence('```GFM\n' + SPEC + '\n```'), SPEC);
+});
+
+test('tolerates surrounding whitespace around the wrapper', () => {
+  assert.equal(stripSpecWrapperFence('\n\n```markdown\n' + SPEC + '\n```\n\n'), SPEC);
+});
+
+test('leaves a normal spec (no leading fence) untouched', () => {
+  assert.equal(stripSpecWrapperFence(SPEC), SPEC);
+});
+
+test('does NOT unwrap a non-markdown language wrapper (```json)', () => {
+  const wrapped = '```json\n{"a":1}\n```';
+  assert.equal(stripSpecWrapperFence(wrapped), wrapped);
+});
+
+test('does NOT unwrap when content follows the first closing fence', () => {
+  // A spec that merely STARTS with a code block, then has prose after it.
+  const doc = '```js\nconst x = 1;\n```\n\nThe code above does X.';
+  assert.equal(stripSpecWrapperFence(doc), doc);
+});
+
+test('does NOT unwrap an ambiguous 3-backtick wrapper with inner 3-backtick fences (F6)', () => {
+  // Inner ``` closes the first block early; boundary is ambiguous, so we bail
+  // and leave it for the four-backtick author guidance to prevent upstream.
+  const doc = '```markdown\n# Spec\n\n```js\nconst x = 1;\n```\n\nmore spec\n```';
+  assert.equal(stripSpecWrapperFence(doc), doc);
+});
+
+test('unwraps a 4-backtick wrapper that legitimately contains inner 3-backtick fences', () => {
+  const inner = '# Spec\n\n```js\nconst x = 1;\n```\n\nmore spec';
+  const wrapped = '````markdown\n' + inner + '\n````';
+  assert.equal(stripSpecWrapperFence(wrapped), inner);
+});
+
+test('is idempotent — unwrapping an already-clean spec is a no-op', () => {
+  const once = stripSpecWrapperFence('```markdown\n' + SPEC + '\n```');
+  assert.equal(stripSpecWrapperFence(once), once);
+  assert.equal(once, SPEC);
+});
+
+test('does not strip an opener with no closing fence', () => {
+  const doc = '```markdown\n' + SPEC; // truncated, never closed
+  assert.equal(stripSpecWrapperFence(doc), doc);
+});
+
+test('handles empty / non-string input gracefully', () => {
+  assert.equal(stripSpecWrapperFence(''), '');
+  assert.equal(stripSpecWrapperFence('   '), '   ');
+  assert.equal(stripSpecWrapperFence(null), null);
+  assert.equal(stripSpecWrapperFence(undefined), undefined);
+});
+
+test('an empty fenced block is left unchanged rather than reduced to nothing', () => {
+  const doc = '```markdown\n```';
+  assert.equal(stripSpecWrapperFence(doc), doc);
+});


### PR DESCRIPTION
A scout/spec-author LLM sometimes wraps its ENTIRE markdown spec in a single
```markdown ... ``` fence (it reads "produce a markdown document" as "emit one
fenced markdown block"). Stored verbatim, that makes the whole spec render as
one big code block in the dev-chat viewer instead of formatted markdown
(session 153; 11 of 82 specs in prod).

- Add stripSpecWrapperFence() (src/services/spec-format.js): conservatively
  unwraps a document that is EXACTLY one fenced block whose info string is
  empty or markdown-ish, with the closing fence as the last line. Leaves specs
  that merely start with a code block, have content after the fence, are tagged
  another language, or have an ambiguous inner-fence boundary untouched.
- Apply it at all three capture sites (scout, write_spec, edit_spec) before
  the spec_md UPDATE and the chat_session_specs snapshot.
- Tell the scout/write_spec prompts explicitly to emit RAW markdown and never
  wrap the whole response in a fence (reduces the rate; the unwrap is the
  load-bearing half since instructions alone won't hit 0%).
- Idempotent migrate.js backfill that unwraps existing chat_sessions.spec_md
  and chat_session_specs.content rows. Runs before backfillOrphanedSpecDrafts
  so unwrapping the live buffer can't churn a new version every boot.
- 13 tests covering the unwrap rules.